### PR TITLE
Geocode blocks/sections of ACT DAs with no addresses

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,14 +1,14 @@
 require 'mechanize'
 require 'scraperwiki'
 require 'date'
+require 'rubygems'
+require 'json'
+require 'net/http'
+require 'open-uri'
 
 agent = Mechanize.new
 url = "http://www.actpla.act.gov.au/topics/your_say/comment/pubnote"
 page = agent.get(url)
-# The way that Mechanize is invoking Nokogiri for parsing the html is for some reason not working with this html which
-# is malformed: See http://validator.w3.org/check?uri=http://apps.actpla.act.gov.au/pubnote/index.asp&charset=(detect+automatically)&doctype=Inline&group=0
-# It's chopping out the content that we're interested in. So, doing the parsing explicitly so we can control how it's done.
-page = Nokogiri::HTML(page.body)
 
 # Walking through the lines. Every 7 lines is a new application
 applications = []
@@ -17,6 +17,39 @@ current_suburb = ''
 page.search('.listing > *').each do |line|
   if line.text.strip! == "Click here to view the plans"
     application[:info_url] = line.children.first["href"]
+        # try to reverse geocode applications with no address
+	if application[:address].nil? or application[:address].include?('NO ADDRESS')
+		suburb = application[:suburb].gsub(/\\/, '\&\&').gsub(/'/, "''")
+		urlsuburb = CGI::escape(suburb)
+		result = ScraperWiki.select("* from swdata where `suburb`='#{suburb}' and `block`='#{application[:block]}' and `section`='#{application[:section]}'")	
+		if (result.empty? rescue true)
+		    puts "geocoding for suburb=#{urlsuburb} block=#{application[:block]} section=#{application[:section]} address=#{application[:address]}"
+		    url = "http://www.actmapi.act.gov.au/actmapi/rest/services/mga/basic/MapServer/75/query?where=SECTION_NUMBER%3D#{application[:section]}+and+BLOCK_NUMBER%3D#{application[:block]}+and+DIVISION_NAME%3D%27#{urlsuburb}%27&outFields=ADDRESSES&returnGeometry=true&outSR=4326&f=pjson"
+		    resp = Net::HTTP.get_response(URI.parse(url))
+  		    data = resp.body
+ 		    result = JSON.parse(data)
+		    if not result['features'].empty? and not result['features'].first['ADDRESSES'].nil?
+			puts result['features'].first['ADDRESSES'].first
+		        application[:address] = result['features'].first['ADDRESSES'].first
+		    end
+		    if not result['features'].empty? and not result['features'].first["geometry"].nil?
+			geom = result['features'].first["geometry"]
+			# just take first point, finding the center is harder and further away from roads http://stackoverflow.com/a/18623672
+			lng = geom["rings"].first.first[0]
+			lat = geom["rings"].first.first[1]
+			gurl = "http://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{lng}&key="
+	                gresp = Net::HTTP.get_response(URI.parse(gurl))
+                        gdata = gresp.body
+                        gresult = JSON.parse(gdata)
+			if not gresult['results'].first['formatted_address'].nil?
+				puts gresult['results'].first['formatted_address']
+				application[:address] = gresult['results'].first['formatted_address']
+			end
+		    end
+		else 
+		    application[:address] = result[0][:address]
+		end
+	end
     applications << application unless application[:address].nil?
     application = {date_scraped: Date.today}
   else
@@ -31,8 +64,11 @@ page.search('.listing > *').each do |line|
       when 'Development Application'
         application[:council_reference] = parts[1].strip!
       when 'Address'
-        application[:address] = "#{parts[1..-1].join(":")}, #{current_suburb}, ACT" unless parts[1].strip! == 'NO ADDRESS'
+        application[:address] = "#{parts[1..-1].join(":").strip!}, #{current_suburb}, ACT"
       when 'Block'
+        application[:block] = parts[1].gsub(" Section","").strip!
+        application[:section] = parts[2].strip!
+        application[:suburb] = current_suburb
       when 'Proposal'
         application[:description] = parts[1..-1].join(":").strip!
       when 'Period for representations closes'


### PR DESCRIPTION
...then geocode back to nearest street name. Is this necessary or is raw lat/lon an acceptable address for PlanningAlerts? 

These blocks tend to be large areas so an alert radius might not capture the single point/address chosen to represent the whole space even if some of the space is in that radius - is there any plans to support polygons? 

There are also still some DAs where the block/section cannot be found (lol.) so NO ADDRESS gets written to the database. Is this okay or should they still be excluded?
