### PR TITLE
Remove invalid characters from utf8 string

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,8 @@ page.search('.listing > *').each do |line|
     if line.text.strip! == ""
       next
     end
-    parts = line.text.split(":")
+  
+    parts = line.text.encode('UTF-16le', :invalid => :replace, :replace => '').encode('UTF-8').split(":")
     if parts.length == 1
       current_suburb = line.text.strip!
     else


### PR DESCRIPTION
Fixes

```
scraper.rb:26:in `split':  invalid byte sequence in UTF-8 (ArgumentError)
    from scraper.rb:26:in `block in <main>'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:238:in `upto'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:238:in `each'
    from scraper.rb:17:in `<main>'
```
